### PR TITLE
Push update available notifications to all installed builds

### DIFF
--- a/getnotifications
+++ b/getnotifications
@@ -10,9 +10,37 @@
         "builds": [],
         "lastUsed": ""
       },
-      "html": "<div style='display: block;height: auto;font-size: 16px;'><div style='display: inline-block;float: left;padding: 7px 65px 7px 5px;font-weight: 500;'>The version of brackets installed in this system is unsupported. <a class='actionable' href='https://brackets.io' style='text-decoration: none;font-weight: 500;'>Get the latest version of Brackets here!</a></div></div>",
+      "html": "<div style='display: block;height: auto;font-size: 16px;'><div style='display: inline-block;float: left;padding: 7px 65px 7px 5px;font-weight: 500;'>The version of brackets installed in this system is unsupported. <a class='actionable' href='https://brackets.io' style='text-decoration: none;font-weight: 500;'>Get the latest version of Brackets(2.0.1) here!</a></div></div>",
       "actionables": ".actionable",
-      "expiry": 1643703382000
+      "expiry": 1766300612000
+    },
+    {
+      "sequence": 1630434600000,
+      "silent": false,
+      "filters": {
+        "platforms": [],
+        "version": "1.14",
+        "locales": [],
+        "builds": [],
+        "lastUsed": ""
+      },
+      "html": "<div style='display: block;height: auto;font-size: 16px;'><div style='display: inline-block;float: left;padding: 7px 65px 7px 5px;font-weight: 500;'>The version of brackets installed in this system is unsupported. <a class='actionable' href='https://brackets.io' style='text-decoration: none;font-weight: 500;'>Get the latest version of Brackets(2.0.1) here!</a></div></div>",
+      "actionables": ".actionable",
+      "expiry": 1766300612000
+    },
+    {
+      "sequence": 1630434600000,
+      "silent": false,
+      "filters": {
+        "platforms": [],
+        "version": "2.0.0",
+        "locales": [],
+        "builds": [],
+        "lastUsed": ""
+      },
+      "html": "<div style='display: block;height: auto;font-size: 16px;'><div style='display: inline-block;float: left;padding: 7px 65px 7px 5px;font-weight: 500;'>The version of brackets installed in this system is unsupported. <a class='actionable' href='https://brackets.io' style='text-decoration: none;font-weight: 500;'>Get the latest version of Brackets(2.0.1) here!</a></div></div>",
+      "actionables": ".actionable",
+      "expiry": 1766300612000
     }
   ]
 }


### PR DESCRIPTION
Push 2.0.1 update notification

## Testing
* Tested locally by overriding update URLs in Brackets 1.14, 1.13, and 2.0.0.
* Verified update notifications not appearing in 2.0.1 builds