### PR TITLE
chrome v111 update breaks live preview notification

### DIFF
--- a/prod/notifications/en.json
+++ b/prod/notifications/en.json
@@ -13,6 +13,34 @@
       "html": "<div style='display: block;height: auto;font-size: 16px;'><div style='display: inline-block;float: left;padding: 7px 65px 7px 5px;font-weight: 500;'>The version of brackets installed in this system is unsupported. <a class='actionable' href='https://brackets.io' style='text-decoration: none;font-weight: 500;'>Get the latest version of Brackets here!</a></div></div>",
       "actionables": ".actionable",
       "expiry": 1643703382000
+    },
+    {
+      "sequence": 1630434600012,
+      "silent": false,
+      "filters": {
+        "platforms": [],
+        "version": "2.0",
+        "locales": [],
+        "builds": [],
+        "lastUsed": ""
+      },
+      "html": "<div style='display: block;height: auto;font-size: 16px;'><div style='display: inline-block;float: left;padding: 7px 65px 7px 5px;font-weight: 500;'>Fix: Live preview is not working after latest Chrome update(Version 111). Please click <a class='actionable' href='https://github.com/brackets-cont/brackets/issues/262' style='text-decoration: none;font-weight: 500;'>here </a> to fix the issue or use <a href='https://phcode.dev' style='text-decoration: none;font-weight: 500;'>phcode.dev</a>. <br/>A New release with the fix will be available by 15'th March.</div></div>",
+      "actionables": ".actionable",
+      "expiry": 1843703382000
+    },
+    {
+      "sequence": 1630434600012,
+      "silent": false,
+      "filters": {
+        "platforms": [],
+        "version": "2.1",
+        "locales": [],
+        "builds": [],
+        "lastUsed": ""
+      },
+      "html": "<div style='display: block;height: auto;font-size: 16px;'><div style='display: inline-block;float: left;padding: 7px 65px 7px 5px;font-weight: 500;'>Fix: Live preview is not working after latest Chrome update(Version 111). Please click <a class='actionable' href='https://github.com/brackets-cont/brackets/issues/262' style='text-decoration: none;font-weight: 500;'>here </a> to fix the issue or use <a href='https://phcode.dev' style='text-decoration: none;font-weight: 500;'>phcode.dev</a>. <br/>A New release with the fix will be available by 15'th March.</div></div>",
+      "actionables": ".actionable",
+      "expiry": 1843703382000
     }
   ]
 }


### PR DESCRIPTION
Emergency notification: Live preview is not working after the latest chrome update. We will be pushing out a fix soon. Notifying users to prevent confusion.

https://github.com/brackets-cont/brackets/issues/262

![image](https://user-images.githubusercontent.com/5336369/223951175-84832d07-e00c-49fd-b8cd-91d0c22cf3b4.png)
